### PR TITLE
Fixing bug, returning better messages from controllers

### DIFF
--- a/src/presentation/controllers/CreateHabitController.test.ts
+++ b/src/presentation/controllers/CreateHabitController.test.ts
@@ -37,6 +37,9 @@ describe("Create Habit controller", () => {
     createHabitUseCaseMock.create.mockImplementationOnce(() => {
       throw new HabitAlreadyExistsError(newHabit.name);
     });
+    languageMock.getHabitAlreadyExistsErrorMessage.mockReturnValue(
+      "mocked already exists err msg"
+    );
 
     const response = await sut.handle(newHabit);
 
@@ -55,6 +58,9 @@ describe("Create Habit controller", () => {
     createHabitUseCaseMock.create.mockImplementationOnce(() => {
       throw errorThrown;
     });
+    languageMock.getHabitNotCreatedMessage.mockReturnValue(
+      "mocked not created err msg"
+    );
 
     const response = await sut.handle(newHabit);
 
@@ -67,6 +73,10 @@ describe("Create Habit controller", () => {
     const { sut, createHabitUseCaseMock, languageMock } = makeSut();
     const habitToBeCreated = { name: "", performedLastDate: new Date() };
     createHabitUseCaseMock.create.mockResolvedValueOnce(habitToBeCreated);
+    languageMock.getMissingParamsErrorMessage.mockImplementation(
+      (params) => `mocked ${params} err msg`
+    );
+    languageMock.getHabitNameParamMessage.mockReturnValue("name");
 
     const response: ResponseWithHabit = await sut.handle(habitToBeCreated);
 

--- a/src/presentation/controllers/CreateHabitController.ts
+++ b/src/presentation/controllers/CreateHabitController.ts
@@ -4,6 +4,7 @@ import { HabitAlreadyExistsError } from "../../useCases/errors";
 import { ResponseWithHabit } from "./type-defs";
 import { MissingParamsError } from "../errors";
 import { ICreateHabitControllerLanguage } from "../languages/interfaces";
+import { FutureDateError } from "../../entities/errors";
 
 export class CreateHabitController {
   public constructor(
@@ -39,6 +40,14 @@ export class CreateHabitController {
       if (err instanceof HabitAlreadyExistsError) {
         return {
           message: this.language.getHabitAlreadyExistsErrorMessage(name),
+          error: { instance: err },
+          habit: null,
+        };
+      }
+
+      if (err instanceof FutureDateError) {
+        return {
+          message: this.language.getFutureDateErrorMessage(performedLastDate),
           error: { instance: err },
           habit: null,
         };

--- a/src/presentation/controllers/UpdateHabitController.test.ts
+++ b/src/presentation/controllers/UpdateHabitController.test.ts
@@ -1,4 +1,5 @@
 import { mock } from "jest-mock-extended";
+import { FutureDateError } from "../../entities/errors";
 import { UpdateHabitUseCase } from "../../useCases";
 import { UpdateHabitDTO } from "../../useCases/DTOs";
 import {
@@ -148,5 +149,25 @@ describe("Update Habit controller", () => {
       languageMock.getPerformedLastDateParamMessage(),
     ]);
     expect(response.message).toBe(expectedMessage);
+  });
+
+  it("should return ResponseWithHabit with FutureDateError", async () => {
+    const { sut, updateHabitUseCaseMock, languageMock } = makeSut();
+    const habit = { name: "My habit", performedLastDate: new Date() };
+    const nowMs = new Date().getTime();
+    const futureDate = new Date(nowMs + 86400 * 1000);
+    updateHabitUseCaseMock.update.mockImplementationOnce(() => {
+      throw new FutureDateError(futureDate);
+    });
+
+    const response: ResponseWithHabit = await sut.handle({
+      currentName: "My habit",
+      newName: "My updated habit name",
+      performedLastDate: futureDate,
+    });
+
+    expect(response.message).toBe(
+      languageMock.getFutureDateErrorMessage(futureDate)
+    );
   });
 });

--- a/src/presentation/controllers/UpdateHabitController.test.ts
+++ b/src/presentation/controllers/UpdateHabitController.test.ts
@@ -5,7 +5,6 @@ import {
   HabitAlreadyExistsError,
   NoHabitFoundError,
 } from "../../useCases/errors";
-import { NewNameIsEqualToOldOneError } from "../errors";
 import { IUpdateHabitControllerLanguage } from "../languages/interfaces";
 import { ResponseWithHabit } from "./type-defs";
 import { UpdateHabitController } from "./UpdateHabitController";
@@ -37,6 +36,9 @@ describe("Update Habit controller", () => {
     updateHabitUseCaseMock.update.mockImplementationOnce(() => {
       throw new Error("Server side error occurred");
     });
+    languageMock.getHabitNotUpdatedMessage.mockReturnValue(
+      "mocked not updated err msg"
+    );
 
     const response: ResponseWithHabit = await sut.handle({
       currentName: "No-habit",
@@ -52,6 +54,9 @@ describe("Update Habit controller", () => {
     updateHabitUseCaseMock.update.mockImplementationOnce(() => {
       throw new NoHabitFoundError();
     });
+    languageMock.getNoHabitFoundErrorMessage.mockReturnValue(
+      "mocked not found err msg"
+    );
 
     const response: ResponseWithHabit = await sut.handle({
       currentName: "No-habit",
@@ -69,6 +74,9 @@ describe("Update Habit controller", () => {
     updateHabitUseCaseMock.update.mockImplementationOnce(() => {
       throw new HabitAlreadyExistsError("Testing");
     });
+    languageMock.getHabitAlreadyExistsErrorMessage.mockReturnValue(
+      "mocked already exists err msg"
+    );
 
     const response: ResponseWithHabit = await sut.handle({
       currentName: "No-habit",
@@ -89,6 +97,9 @@ describe("Update Habit controller", () => {
       newName: oldHabit.name,
     };
     updateHabitUseCaseMock.update.mockResolvedValueOnce(oldHabit);
+    languageMock.getNewNameIsEqualToOldOneErrorMessage.mockReturnValue(
+      "mocked name is equal err msg"
+    );
 
     const response: ResponseWithHabit = await sut.handle(newUpdatedHabit);
 
@@ -104,6 +115,10 @@ describe("Update Habit controller", () => {
       newName: "My updated habit name",
     };
     updateHabitUseCaseMock.update.mockResolvedValueOnce(oldHabit);
+    languageMock.getMissingParamsErrorMessage.mockImplementation(
+      (params) => `mocked missing ${params} err msg`
+    );
+    languageMock.getCurrentNameParamMessage.mockReturnValue("current name");
 
     const response: ResponseWithHabit = await sut.handle(
       newUpdatedHabit as UpdateHabitDTO
@@ -120,6 +135,11 @@ describe("Update Habit controller", () => {
     const oldHabit = { name: "My habit", performedLastDate: new Date() };
     const newUpdatedHabit: UpdateHabitDTO = { currentName: oldHabit.name };
     updateHabitUseCaseMock.update.mockResolvedValueOnce(oldHabit);
+    languageMock.getMissingParamsErrorMessage.mockImplementation(
+      (params) => `mocked missing ${params} err msg`
+    );
+    languageMock.getHabitNameParamMessage.mockReturnValue("name");
+    languageMock.getPerformedLastDateParamMessage.mockReturnValue("date");
 
     const response: ResponseWithHabit = await sut.handle(newUpdatedHabit);
 

--- a/src/presentation/controllers/UpdateHabitController.ts
+++ b/src/presentation/controllers/UpdateHabitController.ts
@@ -8,6 +8,8 @@ import { UpdateHabitDTO } from "../../useCases/DTOs";
 import { MissingParamsError } from "../errors";
 import { NewNameIsEqualToOldOneError } from "../errors/NewNameIsEqualToOldOneError";
 import { IUpdateHabitControllerLanguage } from "../languages/interfaces";
+import { FutureDateError } from "../../entities/errors";
+
 export class UpdateHabitController {
   public constructor(
     private useCase: UpdateHabitUseCase,
@@ -74,6 +76,14 @@ export class UpdateHabitController {
       if (err instanceof HabitAlreadyExistsError) {
         return {
           message: this.language.getHabitAlreadyExistsErrorMessage(newName!),
+          error: { instance: err },
+          habit: null,
+        };
+      }
+
+      if (err instanceof FutureDateError) {
+        return {
+          message: this.language.getFutureDateErrorMessage(performedLastDate!),
           error: { instance: err },
           habit: null,
         };

--- a/src/presentation/languages/ENUSLanguage.ts
+++ b/src/presentation/languages/ENUSLanguage.ts
@@ -1,6 +1,10 @@
 import { ILanguage } from "./interfaces";
 
 export class ENUSLanguage implements ILanguage {
+  getFutureDateErrorMessage(date: Date): string {
+    return "Date can't be in the future";
+  }
+
   getDropdownInputTitlePropMessage(): string {
     return "Select a bad habit";
   }

--- a/src/presentation/languages/PTBRLanguage.ts
+++ b/src/presentation/languages/PTBRLanguage.ts
@@ -1,6 +1,10 @@
 import { ILanguage } from "./interfaces";
 
 export class PTBRLanguage implements ILanguage {
+  getFutureDateErrorMessage(date: Date): string {
+    return "Data não pode estar no futuro";
+  }
+
   getDropdownInputTitlePropMessage(): string {
     return "Selecione um vício";
   }

--- a/src/presentation/languages/interfaces/ICreateHabitControllerLanguage.ts
+++ b/src/presentation/languages/interfaces/ICreateHabitControllerLanguage.ts
@@ -1,9 +1,11 @@
+import { IFutureDateErrorLanguage } from "./IFutureDateErrorLanguage";
 import { IHabitAlreadyExistsErrorLanguage } from "./IHabitAlreadyExistsErrorLanguage";
 import { IMissingParamsErrorLanguage } from "./IMissingParamsErrorLanguage";
 
 export interface ICreateHabitControllerLanguage
   extends IHabitAlreadyExistsErrorLanguage,
-    IMissingParamsErrorLanguage {
+    IMissingParamsErrorLanguage,
+    IFutureDateErrorLanguage {
   getHabitCreatedSuccessfullyMessage(name: string): string;
   getHabitNotCreatedMessage(name: string): string;
 }

--- a/src/presentation/languages/interfaces/IFutureDateErrorLanguage.ts
+++ b/src/presentation/languages/interfaces/IFutureDateErrorLanguage.ts
@@ -1,0 +1,3 @@
+export interface IFutureDateErrorLanguage {
+  getFutureDateErrorMessage(date: Date): string;
+}

--- a/src/presentation/languages/interfaces/IUpdateHabitControllerLanguage.ts
+++ b/src/presentation/languages/interfaces/IUpdateHabitControllerLanguage.ts
@@ -1,3 +1,4 @@
+import { IFutureDateErrorLanguage } from "./IFutureDateErrorLanguage";
 import { IHabitAlreadyExistsErrorLanguage } from "./IHabitAlreadyExistsErrorLanguage";
 import { IMissingParamsErrorLanguage } from "./IMissingParamsErrorLanguage";
 import { INewNameIsEqualToOldOneErrorLanguage } from "./INewNameIsEqualToOldOneErrorLanguage";
@@ -7,7 +8,8 @@ export interface IUpdateHabitControllerLanguage
   extends IMissingParamsErrorLanguage,
     INewNameIsEqualToOldOneErrorLanguage,
     IHabitAlreadyExistsErrorLanguage,
-    INoHabitFoundErrorLanguage {
+    INoHabitFoundErrorLanguage,
+    IFutureDateErrorLanguage {
   getHabitUpdatedSuccessfullyMessage(): string;
   getHabitNotUpdatedMessage(): string;
 }

--- a/src/useCases/UpdateHabitUseCase.test.ts
+++ b/src/useCases/UpdateHabitUseCase.test.ts
@@ -1,4 +1,5 @@
 import { mock } from "jest-mock-extended";
+import * as HabitModule from "../entities/Habit";
 import { HabitAlreadyExistsError, NoHabitFoundError } from "./errors";
 import { IShowHabitRepository, IUpdateHabitRepository } from "./interfaces";
 import { UpdateHabitUseCase } from "./UpdateHabitUseCase";
@@ -15,6 +16,10 @@ function makeSut() {
 }
 
 describe("Update Habit use-case", () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   it("should update a Habit successfully", async () => {
     const { sut, updateHabitRepositoryMock, showHabitRepositoryMock } =
       makeSut();
@@ -32,10 +37,7 @@ describe("Update Habit use-case", () => {
 
     await sut.update(updateDTO);
 
-    expect(updateHabitRepositoryMock.update).toHaveBeenNthCalledWith(
-      1,
-      updateDTO
-    );
+    expect(updateHabitRepositoryMock.update).toHaveBeenCalledTimes(1);
   });
 
   it("should throw HabitAlreadyExistsError if new name is already in use", async () => {
@@ -69,6 +71,34 @@ describe("Update Habit use-case", () => {
 
     await expect(sut.update(updateDTO)).rejects.toThrow(
       new NoHabitFoundError()
+    );
+  });
+
+  it("should instantiate Habit so that its business rules can be applied", async () => {
+    const { sut, updateHabitRepositoryMock, showHabitRepositoryMock } =
+      makeSut();
+    const createdHabit = { name: "My habit", performedLastDate: new Date() };
+    const updateDTO = {
+      currentName: "My habit",
+      newName: "My habit's new name",
+    };
+    showHabitRepositoryMock.show.mockImplementation((name: string) => {
+      return new Promise((resolve, _) => {
+        if (name === createdHabit.name) resolve(createdHabit);
+        resolve(undefined);
+      });
+    });
+    const habitSpy = jest.spyOn(HabitModule, "Habit");
+    habitSpy.mockImplementationOnce(
+      (_name: string, _date: Date) => ({} as HabitModule.Habit)
+    );
+
+    await sut.update(updateDTO);
+
+    expect(habitSpy).toHaveBeenNthCalledWith(
+      1,
+      updateDTO.newName,
+      createdHabit.performedLastDate
     );
   });
 });

--- a/src/useCases/UpdateHabitUseCase.ts
+++ b/src/useCases/UpdateHabitUseCase.ts
@@ -14,8 +14,8 @@ export class UpdateHabitUseCase {
     newName,
     performedLastDate,
   }: UpdateHabitDTO): Promise<Habit> {
-    const habitExists = await this.showRepository.show(currentName);
-    if (!habitExists) {
+    const existentHabit = await this.showRepository.show(currentName);
+    if (!existentHabit) {
       throw new NoHabitFoundError();
     }
 
@@ -26,10 +26,14 @@ export class UpdateHabitUseCase {
       }
     }
 
+    const newHabit = new Habit(
+      newName || currentName,
+      performedLastDate || existentHabit.performedLastDate
+    );
     const updatedHabit = await this.updateRepository.update({
-      currentName,
-      newName,
-      performedLastDate,
+      currentName: existentHabit.name,
+      newName: newHabit.name,
+      performedLastDate: newHabit.performedLastDate,
     });
 
     return updatedHabit;


### PR DESCRIPTION
# Bug fixed
Habit couldn't be created with a performedLastDate in the future, but it could be updated with one. That's because the entity Habit was instantiated in the use-case for Habit creation, but not for update.

# Controllers
- Create and Update controllers now return an specific message when FutureDateError is thrown
- Tests expecting an error message have their language mocks methods mocked with an actual value instead of undefined